### PR TITLE
fix: プラグイン用venvへのパッケージインストールを修正

### DIFF
--- a/scripts/run_hook.sh
+++ b/scripts/run_hook.sh
@@ -12,7 +12,7 @@ VENV_DIR="${PLUGIN_DATA}/venv"
 # 初回または pyproject.toml が更新された場合のみ再インストール
 if ! diff -q "${PLUGIN_ROOT}/pyproject.toml" "${PLUGIN_DATA}/pyproject.toml.cache" >/dev/null 2>&1; then
     uv venv "${VENV_DIR}"
-    uv sync --project "${PLUGIN_ROOT}" --python "${VENV_DIR}/bin/python"
+    VIRTUAL_ENV="${VENV_DIR}" uv pip install --compile-bytecode "${PLUGIN_ROOT}"
     cp "${PLUGIN_ROOT}/pyproject.toml" "${PLUGIN_DATA}/pyproject.toml.cache"
 fi
 


### PR DESCRIPTION
## Summary
- Stop hookで `ModuleNotFoundError: No module named 'claude_obsidian_hook'` が発生する問題を修正
- `uv sync --project` がローカル `.venv` を参照してプラグイン用venvにインストールされなかった
- `VIRTUAL_ENV` 明示設定 + `uv pip install --compile-bytecode` に変更し、確実にプラグイン用venvへインストール

## Changes
- `scripts/run_hook.sh`: 1行変更（`uv sync` → `VIRTUAL_ENV` + `uv pip install --compile-bytecode`）

## Test plan
- [x] プラグイン用venvで `import claude_obsidian_hook.save` が成功することを確認
- [x] 全59テストパス
- [x] ベストプラクティス調査（uv公式ドキュメント・他プラグイン事例）との照合済み
- [x] reviewer + researcher によるダブルチェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)